### PR TITLE
replace all usage of variable `$http_host` with `$host`

### DIFF
--- a/wp-super-cache-nginx.conf.md
+++ b/wp-super-cache-nginx.conf.md
@@ -92,7 +92,7 @@ server {
         }
 
         # Set the cache file (we assume that this server block serves only https requests!)
-        set $cachefile "/wp-content/cache/supercache/$http_host$cache_uri/index-https.html"
+        set $cachefile "/wp-content/cache/supercache/$host$cache_uri/index-https.html"
 
         # Add cache file debug info as header
         add_header X-Cache-File $cachefile;
@@ -131,30 +131,30 @@ server {
 If your server block serves only http requests you should change this line:
 
 ```
-    set $cachefile "/wp-content/cache/supercache/$http_host$cache_uri/index-https.html"
+    set $cachefile "/wp-content/cache/supercache/$host$cache_uri/index-https.html"
 ```
 
 to this:
 
 ```
-    set $cachefile "/wp-content/cache/supercache/$http_host$cache_uri/index.html";
+    set $cachefile "/wp-content/cache/supercache/$host$cache_uri/index.html";
 ```
 
 If your server block serves http and https requests you should change it like this:
 
 ```
-    set $cachefile "/wp-content/cache/supercache/$http_host$cache_uri/index.html";
+    set $cachefile "/wp-content/cache/supercache/$host$cache_uri/index.html";
     if ($scheme = https) {
-        set $cachefile "/wp-content/cache/supercache/$http_host$cache_uri/index-https.html";
+        set $cachefile "/wp-content/cache/supercache/$host$cache_uri/index-https.html";
     }
 ```
 
 In some guides you may find such example:
 ```
     # not very good example, however it works
-    set $cachefile "/wp-content/cache/supercache/$http_host/$cache_uri/index.html";
+    set $cachefile "/wp-content/cache/supercache/$host/$cache_uri/index.html";
     if ($https ~* "on") {
-        set $cachefile "/wp-content/cache/supercache/$http_host/$cache_uri/index-https.html";
+        set $cachefile "/wp-content/cache/supercache/$host/$cache_uri/index-https.html";
     }
 ```
 
@@ -257,7 +257,7 @@ To verify that this feature is enabled during compilation:
 ```
 $ nginx -V
 nginx version: nginx/1.10.2
-built by gcc 4.8.5 20150623 (Red Hat 4.8.5-4) (GCC) 
+built by gcc 4.8.5 20150623 (Red Hat 4.8.5-4) (GCC)
 built with OpenSSL 1.0.1e-fips 11 Feb 2013
 TLS SNI support enabled
 configure arguments: --prefix=/usr/share/nginx --sbin-path=/usr/sbin/nginx --modules-path=/usr/lib64/nginx/modules --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --http-client-body-temp-path=/var/lib/nginx/tmp/client_body --http-proxy-temp-path=/var/lib/nginx/tmp/proxy --http-fastcgi-temp-path=/var/lib/nginx/tmp/fastcgi --http-uwsgi-temp-path=/var/lib/nginx/tmp/uwsgi --http-scgi-temp-path=/var/lib/nginx/tmp/scgi --pid-path=/run/nginx.pid --lock-path=/run/lock/subsys/nginx --user=nginx --group=nginx --with-file-aio --with-ipv6 --with-http_ssl_module --with-http_v2_module --with-http_realip_module --with-http_addition_module --with-http_xslt_module=dynamic --with-http_image_filter_module=dynamic --with-http_geoip_module=dynamic --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_random_index_module --with-http_secure_link_module --with-http_degradation_module --with-http_slice_module --with-http_stub_status_module --with-http_perl_module=dynamic --with-mail=dynamic --with-mail_ssl_module --with-pcre --with-pcre-jit --with-stream=dynamic --with-stream_ssl_module --with-google_perftools_module --with-debug --with-cc-opt='-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic' --with-ld-opt='-Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -Wl,-E'
@@ -299,7 +299,7 @@ Here is what happened when I started this script on my WordPress test install:
 
 ```
 $ cd ~/public_html/
-$ ~/bin/compress_with_gzip_recursively.bash 
+$ ~/bin/compress_with_gzip_recursively.bash
 ./wp-admin/js/editor.js:	 72.6%
 ./wp-admin/js/user-profile.min.js:	 64.4%
 ./wp-admin/js/word-count.min.js:	 57.6%
@@ -853,4 +853,3 @@ $ ~/bin/compress_with_gzip_recursively.bash
 ./wp-includes/fonts/dashicons.ttf:	 37.5%
 ./wp-includes/fonts/dashicons.eot:	  0.4%
 ```
-


### PR DESCRIPTION
The value of variable [`$host`](https://nginx.org/en/docs/http/ngx_http_core_module.html#var_host) might fallback to the current matched [`server_name`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_name) when the [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header in http request is empty or not provided by client:
https://stackoverflow.com/questions/15414810/whats-the-difference-of-host-and-http-host-in-nginx
https://serverfault.com/questions/706438/what-is-the-difference-between-nginx-variables-host-http-host-and-server-na

> Host name from the request line
> When open URL http://example.org/test/ ...
> Most browser send the request like this
```http
GET /test/ HTTP/1.1
Host: example.org
```
> Most browser doesn't send the request like this (but this is valid request)
```http
GET http://example.org/test/ HTTP/1.1
```

and in HTTP/1.1, the existing of `Host` header in the request is mandatory:
https://www.rfc-editor.org/rfc/rfc7230#section-5.4
> RFC 7230           HTTP/1.1 Message Syntax and Routing         June 2014
> 
> 5.4.  Host
> 
>    The "Host" header field in a request provides the host and port
>    information from the target URI, enabling the origin server to
>    distinguish among resources while servicing requests for multiple
>    host names on a single IP address.
> 
>      Host = uri-host [ ":" port ] ; Section 2.7.1
> 
>    A client MUST send a Host header field in all HTTP/1.1 request
>    messages.  If the target URI includes an authority component, then a
>    client MUST send a field-value for Host that is identical to that
>    authority component, excluding any userinfo subcomponent and its "@"
>    delimiter (Section 2.7.1).  If the authority mandatory  component is missing or
>    undefined for the target URI, then a client MUST send a Host header
>    field with an empty field-value.

but in the more recent HTTP/2 and HTTP/3 it allows the client to omit `Host` header in some conditions:

https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1-2.3.1
> The ":authority" pseudo-header field conveys the authority portion (Section 3.2 of [RFC3986]) of the target URI (Section 7.1 of [HTTP]). The recipient of an HTTP/2 request MUST NOT use the Host header field to determine the target URI if ":authority" is present.
> 
> Clients that generate HTTP/2 requests directly MUST use the ":authority" pseudo-header field to convey authority information, unless there is no authority information to convey (in which case it MUST NOT generate ":authority").
> 
> Clients MUST NOT generate a request with a Host header field that differs from the ":authority" pseudo-header field. A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field. The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]). An origin server can apply any normalization method, whereas other servers MUST perform scheme-based normalization (see Section 6.2.3 of [RFC3986]) of the two fields.
> 
> An intermediary that forwards a request over HTTP/2 MUST construct an ":authority" pseudo-header field using the authority information from the control data of the original request, unless the original request's target URI does not contain authority information (in which case it MUST NOT generate ":authority"). Note that the Host header field is not the sole source of this information; see Section 7.2 of [HTTP].
> 
> An intermediary that needs to generate a Host header field (which might be necessary to construct an HTTP/1.1 request) MUST use the value from the ":authority" pseudo-header field as the value of the Host field, unless the intermediary also changes the request target. This replaces any existing Host field to avoid potential vulnerabilities in HTTP routing.
> 
> An intermediary that forwards a request over HTTP/2 MAY retain any Host header field.
> 
> Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information; see Sections 7.1 and 7.2 of [HTTP].
> 
> ":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.

https://www.rfc-editor.org/rfc/rfc9114#section-4.3.1-2.12.1
> ":authority":
> Contains the authority portion of the target URI (Section 3.2 of [URI]). The authority MUST NOT include the deprecated userinfo subcomponent for URIs of scheme "http" or "https".
> 
> To ensure that the HTTP/1.1 request line can be reproduced accurately, this pseudo-header field MUST be omitted when translating from an HTTP/1.1 request that has a request target in a method-specific form; see Section 7.1 of [HTTP]. Clients that generate HTTP/3 requests directly SHOULD use the :authority pseudo-header field instead of the Host header field. An intermediary that converts an HTTP/3 request to HTTP/1.1 MUST create a Host field if one is not present in a request by copying the value of the :authority pseudo-header field.

For me using Chrome 109 it will not carry the `Host` header while requesting and the [nginx-quic](https://github.com/nginx-quic/nginx-quic) will not fallback the value of variable `$http_host` to `:authority` when serving HTTP/3 requests(but HTTP/2 will): https://github.com/nginx-quic/nginx-quic/issues/3

https://serverfault.com/questions/1121579/http3-removes-domain-from-all-links
https://pat.im/1307
https://www.enteroa.com/2022/05/12/oracle-linux-8-x86_64-%ec%84%9c%eb%b2%84%ec%97%90%ec%84%9c-dnfyum%ec%9d%84-%ec%9d%b4%ec%9a%a9%ed%95%9c-nginx-%ec%84%a4%ec%b9%98-%eb%b0%8f-http3-%ea%b5%ac%ed%98%84/